### PR TITLE
fix: corrected bug in checking all tools used

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## The problem
 
 Development of AI tools and applications is a process which requires a lot of manual testing and prompt tweaking.
-Not only this, but for many developers the world of AI feels like "uncharted land"
+Not only this, but for many developers the world of AI feels like "uncharted land".
 
 ## This solution
 
@@ -147,7 +147,7 @@ await expect("What is your surname?").toSemanticallyMatch(
 );
 ```
 
-> :warning: **This matcher is async**: use async await when calling the matcher
+> :warning: **This matcher is async**: use async await when calling the matcher.
 > This library uses a cosine calculation to check the similarity distance between the two strings.
 > When running semantic match, a range of options can pass/fail. Currently, the threshold is set to 0.75.
 
@@ -181,7 +181,7 @@ await expect("What is your surname?").toSatisfyStatement(
 );
 ```
 
-> :warning: **This matcher is async**: use async await when calling the matcher
+> :warning: **This matcher is async**: use async await when calling the matcher.
 > This assertion uses the OpenAI chat completion API, using the gpt-4-turbo model by default. As always, be aware of your API usage!
 
 <hr />
@@ -205,7 +205,7 @@ await expect(getResponse).toHaveUsedSomeTools([
 ]);
 ```
 
-> :warning: **This matcher is async**: use async await when calling the matcher
+> :warning: **This matcher is async**: use async await when calling the matcher.
 > This matcher uses the OpenAI chat completion API to check tool calls.
 
 <hr />

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -36,31 +36,31 @@ export function matchToolCallsToExpectedTools(
   allCheck: boolean
 ) {
   if (isStringArray(expectedTools)) {
+    const matchToolCall = (tool: string) =>
+      toolCalls.findIndex((call) => call.function.name === tool) > -1;
+
     if (allCheck) {
-      return toolCalls.every((call) =>
-        expectedTools.includes(call.function.name)
-      );
+      return expectedTools.every(matchToolCall);
     }
 
-    return toolCalls.some((call) => expectedTools.includes(call.function.name));
+    return expectedTools.some(matchToolCall);
   }
   if (isToolCallArray(expectedTools)) {
-    if (allCheck) {
-      return toolCalls.every((call) =>
-        expectedTools.find(
-          (expectedTool) =>
-            expectedTool.name === call.function.name &&
-            expectedTool.arguments === call.function.arguments
-        )
-      );
-    }
-    return toolCalls.some((call) =>
-      expectedTools.find(
-        (expectedTool) =>
+    const matchToolCall = (
+      expectedTool:
+        | RequiredActionFunctionToolCall.Function
+        | ChatCompletionMessageToolCall.Function
+    ) =>
+      toolCalls.findIndex(
+        (call) =>
           expectedTool.name === call.function.name &&
           expectedTool.arguments === call.function.arguments
-      )
-    );
+      ) > -1;
+
+    if (allCheck) {
+      return expectedTools.every(matchToolCall);
+    }
+    return expectedTools.some(matchToolCall);
   }
   return false;
 }

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -68,7 +68,7 @@ describe("Matchers", () => {
       expect(pollFn).toHaveBeenCalledWith("threadId", "runId");
     });
 
-    it("passes with a match on simple match with function name", async () => {
+    it("passes with a simple match on function name", async () => {
       pollFn.mockImplementationOnce((threadId, runId) => {
         return {
           status: "requires_action",
@@ -181,6 +181,35 @@ describe("Matchers", () => {
         [{ name: "getWeather", arguments: "Albany" }],
         { thread_id: "threadId", id: "runId" } as Run,
         false
+      );
+      expect(pass).toEqual(false);
+      expect(pollFn).toHaveBeenCalledWith("threadId", "runId");
+    });
+
+    it("fails when not all tool calls are matched", async () => {
+      pollFn.mockImplementationOnce((threadId, runId) => {
+        return {
+          status: "requires_action",
+          required_action: {
+            type: "submit_tool_outputs",
+            submit_tool_outputs: {
+              tool_calls: [
+                {
+                  type: "function",
+                  function: {
+                    name: "getWeather",
+                  },
+                },
+              ],
+            },
+          },
+        } as Partial<Run>;
+      });
+      const matchers = getMatchers();
+      const pass = await matchers.assistantTools(
+        ["getWeather", "getTemperature"],
+        { thread_id: "threadId", id: "runId" } as Run,
+        true
       );
       expect(pass).toEqual(false);
       expect(pollFn).toHaveBeenCalledWith("threadId", "runId");


### PR DESCRIPTION
BREAKING CHANGE: Changes the fundamentals of the toHaveUsedAllTools and toHaveUsedAllAssistantTools that will cause existing usages to potentially break

@ranst91 I noticed this when developing the assistant assertions, here is the fix for these two methods. Judging from the README I believe this is how you intended these methods to work, but let me know if I'm mistaken. The test I added does not pass with the current setup, and does with the changes accompanying this PR. Also I've put in what I _think_ is the right semantic release notation for this as a breaking change, but again let me know your thoughts on that.