### PR TITLE
[WIP][DNM] feat: allow custom similarity ranks for toSemanticallyMatch assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,10 @@ If TypeScript is not able to resolve the matcher methods, you can add the follow
 toSemanticallyMatch();
 ```
 
-This allows checking if the response from the AI matches or includes the expected response.
-It uses semantic comparison, which means that "What is your age?" and "When were you born?" could both pass.
-This is in order to allow the natural and flexible nature of using AI.
+This allows checking if the response from the AI semantically matches (i.e. has a similar meaning) to an assertion.
+AI responses are non-deterministic and can therefore result in the same thing being stated in many different ways.
+For example, an AI response requesting the users age could take various forms, e.g. "What is your age?", "When were you born?", etc.
+Semantic matching allows us to ignore the strings character content and perform comparisons based on meaning. For example, we could use this method to assert that the above response semantically matches a string such as "How old are you?"
 
 #### Examples
 
@@ -139,17 +140,24 @@ const response = await ai.getResponse("Hello");
 await expect(response).toSemanticallyMatch("What is your flight number?");
 ```
 
-or
-
 ```javascript
 await expect("What is your surname?").toSemanticallyMatch(
   "What is your last name?"
 );
 ```
 
-> :warning: **This matcher is async**: use async await when calling the matcher
-> This library uses a cosine calculation to check the similarity distance between the two strings.
-> When running semantic match, a range of options can pass/fail. Currently, the threshold is set to 0.75.
+```javascript
+// Specifying the matching rank. Options are "low", "mid" (default) and "high"
+await expect("What is your surname?").toSemanticallyMatch(
+  "What is your last name?",
+  "low"
+);
+```
+
+> :warning: **This matcher is async**: use async await when calling the matcher.
+> This library makes requests to the OpenAI API to determine the embeddings for both strings. As always, be aware of your API usage!
+> It uses a cosine calculation to check the similarity distance between the two strings.
+> When running semantic match, a range of options can pass/fail. Currently, the threshold is set to 0.75 ("mid").
 
 <hr />
 
@@ -181,7 +189,7 @@ await expect("What is your surname?").toSatisfyStatement(
 );
 ```
 
-> :warning: **This matcher is async**: use async await when calling the matcher
+> :warning: **This matcher is async**: use async await when calling the matcher.
 > This assertion uses the OpenAI chat completion API, using the gpt-4-turbo model by default. As always, be aware of your API usage!
 
 <hr />
@@ -205,7 +213,7 @@ await expect(getResponse).toHaveUsedSomeTools([
 ]);
 ```
 
-> :warning: **This matcher is async**: use async await when calling the matcher
+> :warning: **This matcher is async**: use async await when calling the matcher.
 > This matcher uses the OpenAI chat completion API to check tool calls.
 
 <hr />
@@ -247,7 +255,7 @@ await expect(run).toHaveUsedAllAssistantTools([
 ]);
 ```
 
-> :warning: **This matcher is async**: use async await when calling the matcher
+> :warning: **This matcher is async**: use async await when calling the matcher.
 > This matcher polls the OpenAI Run API to check for tool calls.
 
 <hr />
@@ -275,7 +283,7 @@ await expect(getResponse).toHaveUsedAllTools([
 ]);
 ```
 
-> :warning: **This matcher is async**: use async await when calling the matcher
+> :warning: **This matcher is async**: use async await when calling the matcher.
 > This matcher uses the OpenAI chat completion API to check tool calls.
 
 <hr />
@@ -317,7 +325,7 @@ await expect(run).toHaveUsedAllAssistantTools([
 ]);
 ```
 
-> :warning: **This matcher is async**: use async await when calling the matcher
+> :warning: **This matcher is async**: use async await when calling the matcher.
 > This matcher polls the OpenAI Run API to check for tool calls.
 
 <hr />

--- a/src/matchers/to-semantically-match.ts
+++ b/src/matchers/to-semantically-match.ts
@@ -5,10 +5,11 @@ import { MatcherUtils } from "expect";
 export async function toSemanticallyMatch(
   this: MatcherUtils,
   received: string,
-  expected: string
+  expected: string,
+  rank: Similarity = Similarity.MID
 ) {
   const matchers = getMatchers();
-  const pass = await matchers.semantic(Similarity.MID, expected, received);
+  const pass = await matchers.semantic(rank, expected, received);
 
   if (pass) {
     return {

--- a/src/utils/similarity.ts
+++ b/src/utils/similarity.ts
@@ -1,13 +1,13 @@
 export enum Similarity {
-	LOW = 'low',
-	MID = 'mid',
-	HIGH = 'high',
+  LOW = "low",
+  MID = "mid",
+  HIGH = "high",
 }
 
 export enum SimilarityConfidenceThreshold {
-	LOW = 0.7,
-	MID = 0.75,
-	HIGH = 0.85,
+  LOW = 0.7,
+  MID = 0.75,
+  HIGH = 0.85,
 }
 
 export function isSimilarByScore(rank: Similarity, score: number): boolean {
@@ -15,14 +15,14 @@ export function isSimilarByScore(rank: Similarity, score: number): boolean {
 	const midSimilarity = score > SimilarityConfidenceThreshold.MID && score < SimilarityConfidenceThreshold.HIGH;
 	const lowSimilarity = score < SimilarityConfidenceThreshold.LOW;
 
-	switch(rank) {
-		case Similarity.HIGH:
-			return highSimilarity;
-		case Similarity.MID:
-			return midSimilarity || highSimilarity;
-		case Similarity.LOW:
-			return lowSimilarity || midSimilarity || highSimilarity;
-		default:
-			return false;
-	}
+  switch (rank) {
+    case Similarity.HIGH:
+      return highSimilarity;
+    case Similarity.MID:
+      return midSimilarity || highSimilarity;
+    case Similarity.LOW:
+      return lowSimilarity || midSimilarity || highSimilarity;
+    default:
+      return false;
+  }
 }

--- a/types/matchers.d.ts
+++ b/types/matchers.d.ts
@@ -1,48 +1,49 @@
-import { z } from 'zod';
+import { z } from "zod";
+import type { Similarity } from "../src/utils/similarity";
 
 declare namespace matchers {
-	interface JestAIMatchers<E, R> {
-		/**
-		 * @description
-		 * Assert whether a value is included in the larger AI response through semantic search
-		 *
-		 * @example
-		 * expect('What is your name?').toSemanticallyMatch('Hello, I am a virtual assistant, let's start off with an introduction. What is your first name?')
-		 *
-		 */
-		toSemanticallyMatch(expected?: string): R
-		/**
-		 * @description
-		 * Assert whether a tool has been used in the AI response
-		 *
-		 * @example
-		 * expect(() => callLLM()).toHaveUsedSomeTools(['get_flight_information'])
-		 *
-		 */
-		toHaveUsedSomeTools(expected?: string[]): R
-		/**
-		 * @description
-		 * Assert whether all tools in the list were used in the AI response
-		 *
-		 * @example
-		 * expect(() => callLLM()).toHaveUsedAllTools(['get_flight_information', 'get_flight_status'])
-		 *
-		 */
-		toHaveUsedAllTools(expected?: string[]): R
-		/**
-		 * @description
-		 * Assert whether an AI response matches a Zod schema
-		 *
-		 * @example
-		 * expect(llmResponse).toMatchZodSchema(z.Object({ name: z.string(), age: z.number() }))
-		 *
-		 */
-		toMatchZodSchema(expected?: z.Schema<any, any>): R
-	}
+  interface JestAIMatchers<E, R> {
+    /**
+     * @description
+     * Assert whether a value is included in the larger AI response through semantic search
+     *
+     * @example
+     * expect('What is your name?').toSemanticallyMatch('Hello, I am a virtual assistant, let's start off with an introduction. What is your first name?')
+     *
+     */
+    toSemanticallyMatch(expected?: string, rank?: Similarity): R;
+    /**
+     * @description
+     * Assert whether a tool has been used in the AI response
+     *
+     * @example
+     * expect(() => callLLM()).toHaveUsedSomeTools(['get_flight_information'])
+     *
+     */
+    toHaveUsedSomeTools(expected?: string[]): R;
+    /**
+     * @description
+     * Assert whether all tools in the list were used in the AI response
+     *
+     * @example
+     * expect(() => callLLM()).toHaveUsedAllTools(['get_flight_information', 'get_flight_status'])
+     *
+     */
+    toHaveUsedAllTools(expected?: string[]): R;
+    /**
+     * @description
+     * Assert whether an AI response matches a Zod schema
+     *
+     * @example
+     * expect(llmResponse).toMatchZodSchema(z.Object({ name: z.string(), age: z.number() }))
+     *
+     */
+    toMatchZodSchema(expected?: z.Schema<any, any>): R;
+  }
 }
 
 // Needs to extend Record<string, any> to be accepted by expect.extend()
 // as it requires a string index signature.
 declare const matchers: matchers.JestAIMatchers<any, void> &
-	Record<string, any>
-export = matchers
+  Record<string, any>;
+export = matchers;


### PR DESCRIPTION
@ranst91 - looking to get your opinion on some modifications/additions to the semantic matching assertion functionality. I've added here the ability to specify the rank in the second argument, so you can now do something like:
```javascript
  await expect("Jaryd won the tour de france in 2023").toSemanticallyMatch(
      "The winner of the 2022 World Cup was Bob",
      "mid"
   );
```

However, looking at your implementation for the "low" rank makes me think there's a bug there, because it is currently calculating as true when the similarity is _less_ than the low rank (0.7) instead of above:
`lowSimilarity = score < SimilarityConfidenceThreshold.LOW`

Overall though this made me realise that there are likely two use cases here:
1. asserting on semantic similarity, and
2. asserting on semantic difference

So there are a few options, any of which I'm happy to code into this PR
1. We fix the lowSimilarity constant so that it passes when above the low rank
2. We add a toNotSemanticallyMatch method which takes an assertion and an  _upper bound_ rank/number
3. We move away from the rank enum and instead have the user provide a number between 0 and 1
  a) I somewhat prefer this, because it ultimately provides a lot more flexibility to the user
4. We raise the default. 0.75 captures quite a bit of similarity. For example "The winner of the 2022 World Cup was Bob" and "Jaryd won the tour de france in 2023" have a cosine similarity of 0.803, but are their meaning is quite different. "Jaryd won the tour de france in 2023" and "The winner of the 2023 tour de france was Jaryd" have a similarity of 0.964.

Interested in your thoughts!