### PR TITLE
fix(config): update custom cli config

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "vitest.js"
   ],
   "scripts": {
-    "build": "rollup -c --mini",
+    "build": "rollup -c --configMini",
     "dev": "rollup -c -w --sourcemaps",
     "test": "jest"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,7 +17,7 @@ export default CLIArgs => {
         resolve(),    // Resolves node_modules imports
         commonjs(),   // Converts CommonJS modules to ES6
     ];
-    if (CLIArgs.mini) {
+    if (CLIArgs.configMini) {
       plugins.push(terser()); // Minify the output (optional)
     }
     return {


### PR DESCRIPTION
Seems like [rollup requires custom configs to be prefixed with `config` ](https://rollupjs.org/command-line-interface/#configuration-files:~:text=You%20can%20even%20define%20your%20own%20command%20line%20options%20if%20you%20prefix%20them%20with%20config)

Before: 
![Screenshot 2024-07-04 at 5 21 22 PM](https://github.com/codeably-io/jest-ai/assets/23294131/4bcdbb0e-5a7f-4820-bc90-9618247033f1)

After:
![image](https://github.com/codeably-io/jest-ai/assets/23294131/8a4b2550-1ce1-4628-ac94-f0dfc7b1cb44)
